### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/variant_parser.go
+++ b/variant_parser.go
@@ -379,6 +379,9 @@ func varParseString(s string) (string, error) {
 			if err != nil {
 				return "", err
 			}
+			if r > math.MaxInt32 {
+				return "", errors.New("unicode escape value out of range")
+			}
 			buf.WriteRune(rune(r))
 			s = s[8:]
 		default:


### PR DESCRIPTION
### **User description**
Potential fix for [https://github.com/khulnasoft/dbus/security/code-scanning/2](https://github.com/khulnasoft/dbus/security/code-scanning/2)

To fix the problem, we need to ensure that the value returned by `strconv.ParseUint` fits within the range of `int32` before converting it to a `rune`. We can achieve this by adding a bounds check to ensure that the parsed value does not exceed `math.MaxInt32`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix incorrect conversion between integer types when parsing unicode escape sequences in strings. Prevent potential overflow by checking if the parsed integer value exceeds the maximum value of `int32` before converting it to a rune.


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect conversion between integer types in `varParseString`.

- Add bounds check for `strconv.ParseUint` to prevent overflow.

- Return error if unicode escape value exceeds `math.MaxInt32`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variant_parser.go</strong><dd><code>Add bounds check for unicode escape parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

variant_parser.go

<li>Added a bounds check for <code>strconv.ParseUint</code> result.<br> <li> Ensured parsed value does not exceed <code>math.MaxInt32</code>.<br> <li> Return an error if the value is out of range.


</details>


  </td>
  <td><a href="https://github.com/khulnasoft/dbus/pull/1/files#diff-0bf278b72d0427c547b70b3b250a0d64e1841016dfdcce93e73e44c3eddf651d">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>